### PR TITLE
execution quirks are set, it still needs, (&&) and change dir commands

### DIFF
--- a/collect_commands.c
+++ b/collect_commands.c
@@ -6,7 +6,7 @@
 /*   By: dopereir <dopereir@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/30 08:48:55 by dopereir          #+#    #+#             */
-/*   Updated: 2025/06/30 11:09:31 by dopereir         ###   ########.fr       */
+/*   Updated: 2025/07/04 00:51:45 by dopereir         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,7 @@ static t_command	*copy_simple_cmd(t_command *src)
 		return (NULL);
 	dest->type = src->type;
 	dest->next_is_pipe = src->next_is_pipe;
+	dest->next_is_and = src->next_is_and;
 	if (src->name)
 		dest->name = ft_strdup(src->name);
 	if (src->path)
@@ -31,8 +32,8 @@ static t_command	*copy_simple_cmd(t_command *src)
 		dest->input_file = ft_strdup(src->input_file);
 	if (src->output_file)
 		dest->output_file = ft_strdup(src->output_file);
-	if (src->filename)
-		dest->filename = ft_strdup(src->filename);
+	if (src->hd_delim)
+		dest->hd_delim = ft_strdup(src->hd_delim);
 	dest->pid_filename_output = src->pid_filename_output;
 	while (i < MAX_ARGS && src->argv[i])
 	{
@@ -132,7 +133,7 @@ void	print_parsed_data(const t_parse_data *pd)
 		printf("Path: %s\n", cmd->path ? cmd->path : "(null)");
 		printf("Input Redir: %s\n", cmd->input_file ? cmd->input_file : "(none)");
 		printf("Output Redir: %s\n", cmd->output_file ? cmd->output_file : "(none)");
-		printf("Heredoc File: %s\n", cmd->filename ? cmd->filename : "(none)");
+		printf("Heredoc Delimiter: %s\n", cmd->hd_delim ? cmd->hd_delim : "(none)");
 		printf("Pipe flag: %d\n", cmd->next_is_pipe);
 		printf("PID Filename Output: %d\n", (int)cmd->pid_filename_output);
 

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: dopereir <dopereir@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/28 23:15:37 by dopereir          #+#    #+#             */
-/*   Updated: 2025/06/30 22:31:57 by dopereir         ###   ########.fr       */
+/*   Updated: 2025/07/03 23:57:48 by dopereir         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,8 +77,8 @@ void print_command_tree(t_command *cmd, int depth)
 		if (cmd->type == T_REDIR_APPEND && cmd->output_file) {
 			indent(depth); printf("    >> %s\n", cmd->output_file);
 		}
-		if (cmd->type == T_REDIR_HEREDOC && cmd->filename) {
-			indent(depth); printf("    << %s\n", cmd->filename);
+		if (cmd->type == T_REDIR_HEREDOC && cmd->hd_delim) {
+			indent(depth); printf("    << %s\n", cmd->hd_delim);
 		}
 	}
 
@@ -289,7 +289,7 @@ int main(void)
 	lexer->tokens = NULL;
 	lexer->token_count = 0;
 
-	while (keepRunning)
+	while (1)
 	{
 		input = readline("MINISHELL>$ ");
 
@@ -361,85 +361,7 @@ int main(void)
 	}
 
 	free(lexer);
+	//add cleanup functions if needed
 	printf("Programa finalizado.\n");
 	return (0);
 }
-
-// MAIN ALTERADA
-/* int main(void)
-{
-	t_lexer *lexer;
-	t_parse_data *parse_data;
-
-	lexer = malloc(sizeof(t_lexer));
-	if (!lexer)
-		return (1);
-	lexer->input = NULL;
-	lexer->tokens = NULL;
-	lexer->token_count = 0;
-	int keepRunning = 1;
-	while (keepRunning)
-	{
-		lexer->input = readline("PROMPT>$ ");
-		if (!lexer->input)
-		{
-			printf("exit\n");
-			break;
-		}
-		if (lexer->input[0] != '\0')
-		{
-			lexing_input(lexer, ' ');
-			if (lexer->token_count > 0)
-			{
-				printf("\n=== TOKENS ===\n");
-				print_tokens(lexer);
-				parse_data = parse_input(lexer);
-				if (parse_data)
-				{
-					print_parsed_commnads(parse_data);
-					execute_parsed_commands(parse_data);
-					free_parse_data(parse_data);
-				}
-			}
-		}
-		add_history(lexer->input);
-	}
-	free(lexer->input);
-	lexer->input = NULL;
-	if (lexer->tokens)
-		clear_token(lexer->tokens, lexer->token_count);
-	free(lexer);
-	return (0);
-} */
-//MAIN ORIGINAL
-/* int	main(void)
-{
-	t_lexer	*lexer;
-
-	lexer = malloc(sizeof(t_lexer));
-	lexer->input = NULL;
-	lexer->tokens = NULL;
-	//lexer->path = NULL;
-	lexer->token_count = 0;
-
-	int	flag = 1;
-
-	while(flag)
-	{
-		lexer->input = readline("PROMPT>$ "); // READ (1/2)
-		if (lexer->input)
-		{
-			lexing_input(lexer, ' '); // READ(2/2)
-			print_tokens(lexer); // PRINT TOKENS
-			// execute(lexer);
-			//parse_function(lexer);
-				// criar t_parse_data ->
-			// execute t_parse_data ->
-			add_history(lexer->input);
-			free (lexer->input);
-		}
-		//keepRunning = 0;
-		//printf("KEEP RUNNING: %d\n", keepRunning);
-	}
-	return (0);
-} */

--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,7 @@
 /*   By: dopereir <dopereir@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/20 01:10:10 by dopereir          #+#    #+#             */
-/*   Updated: 2025/06/30 10:45:25 by dopereir         ###   ########.fr       */
+/*   Updated: 2025/07/03 23:55:16 by dopereir         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,7 @@ typedef struct s_parsephase_data
 	int				n_cmds;
 }			t_parse_data;
 
-static volatile	int	keepRunning = 1;
+static volatile sig_atomic_t	g_heredoc_sig = 0;
 extern	char		**environ;
 
 // cd /some/path/ && ls | grep *.txt > output.txt && cat output.txt

--- a/parser.c
+++ b/parser.c
@@ -18,46 +18,42 @@
 
 t_command *init_command(void)
 {
-    t_command *cmd;
-    int i;
+	t_command	*cmd;
+	int			i;
 
-    cmd = malloc(sizeof(t_command));
-    if (!cmd)
-        return NULL;
-
-    // Inicializar todos os campos
-    cmd->type = T_WORD;
-    cmd->name = NULL;
-    cmd->path = NULL;
-    cmd->input_file = NULL;
-    cmd->output_file = NULL;
-    cmd->filename = NULL;
-    cmd->pid_filename_output = 0;
-    cmd->command_count = 0;
-    cmd->commands = NULL;
-    cmd->left = NULL;
-    cmd->right = NULL;
+	cmd = malloc(sizeof(t_command));
+	if (!cmd)
+		return NULL;
+	cmd->type = T_WORD;
+	cmd->name = NULL;
+	cmd->path = NULL;
+	cmd->input_file = NULL;
+	cmd->output_file = NULL;
+	cmd->filename = NULL;
+	cmd->pid_filename_output = 0;
+	cmd->command_count = 0;
+	cmd->commands = NULL;
+	cmd->left = NULL;
+	cmd->right = NULL;
 	cmd->next_is_pipe = 0;
 	cmd->next_is_and = 0;
 	cmd->hd_delim = NULL;
-
-    // Inicializar array argv
-    i = 0;
-    while (i < MAX_ARGS)
-    {
-        cmd->argv[i] = NULL;
-        i++;
-    }
-
-    return cmd;
+	i = 0;
+	while (i < MAX_ARGS)
+	{
+		cmd->argv[i] = NULL;
+		i++;
+	}
+	return (cmd);
 }
 
 t_command	*parse_simple_command(t_lexer *lexer)
 {
+	printf("**** ENTER PARSE_SIMPLE_CMD ******\n");
 	t_command	*cmd;
-	int	args_count;
-	int	i;
-	int	arg_index;
+	int			args_count;
+	int			i;
+	int			arg_index;
 
 	i = 0;
 	arg_index = 0;
@@ -112,7 +108,7 @@ t_command	*parse_simple_command(t_lexer *lexer)
 			{
 				printf("minishell: syntax error near unexpected token\n");
 				free_command(cmd);
-				return NULL; // falta o nome do arquivo de entrada
+				return (NULL); // falta o nome do arquivo de entrada
 			}
 		}
 		else if (lexer->tokens[i].type == T_REDIR_OUT || lexer->tokens[i].type == T_REDIR_APPEND)
@@ -173,6 +169,7 @@ t_command	*parse_simple_command(t_lexer *lexer)
 
 t_command	*parse_pipeline(t_lexer *lexer)
 {
+	printf("**** ENTER PARSE_PIPELINE ******\n");
 	t_command	*pipeline_cmd;
 	t_lexer		*sublexer;
 	int		start;
@@ -230,6 +227,7 @@ t_command	*parse_pipeline(t_lexer *lexer)
 
 t_command	*parse_sequence(t_lexer *lexer)
 {
+	printf("**** ENTER PARSE_SEQUENCE ******\n");
 	t_command	*sequence_cmd;
 	t_lexer		*sublexer;
 	int		start;


### PR DESCRIPTION
1. Added a variable to the t_command struct->next_is_and, to prepare handling of (&&) commands,
2. Changed the heredoc behavior, previously used cmd->filename as argument, now uses a specific cmd->hd_delim as delimiter argument.
3. Changes on execution order to accommodate combined cases of heredoc, and redirections.
4. Removed the global var keepRunning, is not need anymore, on the main.c main loop, we just use a while (1), since we can only use one global variable and cannot contain program data, i defined a global variable to receive signals. By now is only used in heredoc, the same variable will be used at the signal handlers at other parts in the program.
5. erased the old main's , i think we will not need anyways

NEXT STEPS:

1. begin to refactor functions to comply with norminette
2. add error handling function,
3. implement built-ins
4. work with enviroment variables