### PR TITLE
more descriptive message on the pull request,

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LIBFT = $(LIBFT_DIR)/libft.a
 SOURCES = main.c tokenizer.c parser.c parser_utils.c built_ins.c error_handlers.c \
 		collect_commands.c exec_commands.c environment_functions.c cleanup_env_list.c \
 		execute_helpers.c redirections_utils.c environment_functions_utils.c \
-		heredoc_utils.c \
+		heredoc_utils.c expand_var.c signal_handlers.c \
 
 OBJ = $(SOURCES:.c=.o)
 

--- a/built_ins.c
+++ b/built_ins.c
@@ -6,7 +6,7 @@
 /*   By: dopereir <dopereir@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 17:17:58 by dopereir          #+#    #+#             */
-/*   Updated: 2025/07/06 19:16:45 by dopereir         ###   ########.fr       */
+/*   Updated: 2025/07/19 02:12:13 by dopereir         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,25 +30,13 @@ int	ft_cd(char **argv, t_env **env_list)
 	else
 		target = argv[1];
 	if (!target)
-	{
-		fprintf(stderr, "minishell: cd: HOME or OLDPWD not set\n");
 		return (1);
-	}
 	if (!getcwd(oldpwd, sizeof(oldpwd)))
-	{
-		perror("minishell: cd");
-		return (1);
-	}
+		return (perror("minishell: cd"), 1);
 	if (chdir(target) != 0)
-	{
-		perror("minishell: cd");
-		return (1);
-	}
+		return (perror("minishell: cd"), 1);
 	if (!getcwd(newpwd, sizeof(newpwd)))
-	{
-		perror("minishell: cd");
-		return (1);
-	}
+		return (perror("minishell: cd"), 1);
 	ft_setenv(env_list, "OLDPWD", oldpwd);
 	ft_setenv(env_list, "PWD", newpwd);
 	return (0);

--- a/collect_commands.c
+++ b/collect_commands.c
@@ -6,7 +6,7 @@
 /*   By: dopereir <dopereir@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/30 08:48:55 by dopereir          #+#    #+#             */
-/*   Updated: 2025/07/04 23:25:52 by dopereir         ###   ########.fr       */
+/*   Updated: 2025/07/19 01:48:27 by dopereir         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -94,7 +94,7 @@ void	free_parsed_data(t_parse_data *parsed_data)
 // > format_parsed_data(t_lexer *lexer)
 // copy the data returned by parse_function into a t_parse_data structure,
 // and free the original data
-t_parse_data	format_parsed_data(t_lexer *lexer)
+t_parse_data	format_parsed_data(t_lexer *lexer, t_env *my_env)
 {
 	t_parse_data	parsed_data;
 	t_command		*root;
@@ -104,7 +104,7 @@ t_parse_data	format_parsed_data(t_lexer *lexer)
 	i = 0;
 	while (i < MAX_ARGS)
 		parsed_data.commands[i++] = NULL;
-	root = parse_function(lexer);
+	root = parse_function(lexer, my_env);
 	if (!root)
 		return (parsed_data);
 	collect_commands(root, &parsed_data);

--- a/execute_helpers.c
+++ b/execute_helpers.c
@@ -51,7 +51,7 @@ char	*cmd_path_generator(char *cmd_name)
 
 	if (!cmd_name || !*cmd_name)
 		return (NULL);
-	result = NULL;
+	result = cmd_name;
 	paths = ft_split(getenv("PATH"), ':');
 	if (!paths)
 		return (NULL);

--- a/expand_var.c
+++ b/expand_var.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   expand_var.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nayara <nayara@student.42.fr>              +#+  +:+       +#+        */
+/*   By: dopereir <dopereir@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/03 17:46:12 by nayara            #+#    #+#             */
-/*   Updated: 2025/07/08 13:24:43 by nayara           ###   ########.fr       */
+/*   Updated: 2025/07/19 01:48:37 by dopereir         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,16 +33,29 @@ char	*get_special_var(char *var_name, t_lexer *lexer)
 		return (ft_strdup(""));
 	else if (ft_strcmp(var_name, "!") == 0)
 	{
-		 if (lexer->last_bg_pid > 0)
-		 	return (ft_itoa(lexer->last_bg_pid));
+		if (lexer->last_bg_pid > 0)
+			return (ft_itoa(lexer->last_bg_pid));
 		else
 			return (ft_strdup(""));
 	}
 	return (NULL);
 }
-int	expand_variables(t_lexer *lexer)
+
+int	set_value(char *var_value, char	*var_name, t_lexer *lexer, t_env *my_env)
 {
-	int	i;
+	var_value = get_special_var((char *)var_name, lexer);
+	if (!var_value)
+		var_value = ft_getenv(my_env, var_name);
+	if (!var_value)
+		var_value = ft_strdup("");
+	if (!var_value)
+		return (-1);
+	return (0);
+}
+
+int	expand_variables(t_lexer *lexer, t_env *my_env)
+{
+	int		i;
 	char	*var_name;
 	char	*var_value;
 	char	*old_text;
@@ -52,12 +65,12 @@ int	expand_variables(t_lexer *lexer)
 	{
 		if (lexer->tokens[i].type == T_VAR)
 		{
-			var_name = lexer->tokens[i].text + 1; // pula o $
+			var_name = lexer->tokens[i].text + 1;
 			var_value = get_special_var((char *)var_name, lexer);
 			if (!var_value)
-				var_value = getenv(var_name);
+				var_value = ft_getenv(my_env, var_name);
 			if (!var_value)
-				var_value = ft_strdup(""); // Variável não encontrada
+				var_value = ft_strdup("");
 			if (!var_value)
 				return (-1);
 			old_text = lexer->tokens[i].text;

--- a/heredoc_utils.c
+++ b/heredoc_utils.c
@@ -10,7 +10,14 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "libft/libft.h"
 #include "minishell.h"
+#include "parser.h"
+#include <asm-generic/ioctls.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
 
 static int	create_pipe(int pipefd[2])
 {
@@ -24,35 +31,47 @@ static int	create_pipe(int pipefd[2])
 
 static void	restore_signals(const struct sigaction *orig)
 {
-	sigaction(SIGINT, orig, NULL);
-	sigaction(SIGQUIT, &(struct sigaction){.sa_handler = SIG_DFL}, NULL);
+	struct sigaction	dfl;
+
+	ft_memset(&dfl, 0, sizeof(dfl));
+
+	sigaction(SIGINT, orig, NULL);//restore sigint
+	dfl.sa_handler = SIG_DFL;//restore sigquit to default
+	sigemptyset(&dfl.sa_mask);
+	dfl.sa_flags = 0;
+	sigaction(SIGQUIT, &dfl, NULL);
 }
+
 
 static void	setup_signals(struct sigaction *orig)
 {
 	struct sigaction	sa;
 	struct sigaction	ign;
 
-	sigemptyset(&sa.sa_mask);
-	sa.sa_flags = SA_RESTART;
+	ft_memset(&sa, 0, sizeof(sa));
+	ft_memset(&ign, 0, sizeof(ign));
+
 	sa.sa_handler = heredoc_sig_handler;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
 	sigaction(SIGINT, &sa, orig);
+
 	ign.sa_handler = SIG_IGN;
 	sigemptyset(&ign.sa_mask);
 	ign.sa_flags = 0;
 	sigaction(SIGQUIT, &ign, NULL);
 }
 
-static int	read_heredoc(int write_fd, char *delim, int *got_sig)
+static int	read_heredoc(int write_fd, char *delim)
 {
 	char	*line;
 
-	while (!*got_sig)
+	while (!g_heredoc_sig)
 	{
 		line = readline("> ");
 		if (!line)
 		{
-			*got_sig = 1;
+			g_heredoc_sig = 1;
 			break ;
 		}
 		if (ft_strcmp(line, delim) == 0)
@@ -60,31 +79,147 @@ static int	read_heredoc(int write_fd, char *delim, int *got_sig)
 			free(line);
 			break ;
 		}
-		write(write_fd, line, strlen(line));
+		write(write_fd, line, ft_strlen(line));
 		write(write_fd, "\n", 1);
 		free(line);
 	}
-	return (*got_sig);
+	return (g_heredoc_sig);
 }
 
 int	set_heredoc(char *delim)
 {
 	int					pipefd[2];
 	struct sigaction	orig_int;
+	struct sigaction	parent_int;
+	struct sigaction	ign;
 	int					aborted;
+	pid_t				pid;
+	int					status;
 
 	if (create_pipe(pipefd) < 0)
 		return (-1);
-	setup_signals(&orig_int);
-	aborted = read_heredoc(pipefd[1], delim, (int *)&g_heredoc_sig);
-	restore_signals(&orig_int);
-	close(pipefd[1]);
-	if (aborted)
+	pid = fork();
+	if (pid < 0)
 	{
-		ft_printf("minishell: warning: here-document "
-			"delimited by end-of-file (wanted '%s')\n", delim);
+		perror("minishell: heredoc fork:");
+		close(pipefd[0]);
+		close(pipefd[1]);
+		return (-1);
+	}
+	else if (pid == 0) //processo filho
+	{
+		close(pipefd[0]);
+
+		setup_signals(&orig_int);
+		aborted = read_heredoc(pipefd[1], delim);
+		restore_signals(&orig_int);
+		close(pipefd[1]);
+		if (aborted == 1)
+			_exit(1);
+		else if (aborted == 0)
+			_exit(0);
+	}
+	close(pipefd[1]);
+
+	sigaction(SIGINT, NULL, &parent_int);
+	ign.sa_handler = SIG_IGN;
+	sigemptyset(&ign.sa_mask);
+	ign.sa_flags = 0;
+	sigaction(SIGINT, &ign, NULL);//ignore SIGINT
+
+	waitpid(pid, &status, 0);
+
+	sigaction(SIGINT, &parent_int, NULL);
+	if (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT)
+	{
 		g_heredoc_sig = 0;
 		return (pipefd[0]);
 	}
+	if (WIFEXITED(status) && WEXITSTATUS(status) == 1)
+	{
+		ft_printf("minishell: warning: here-document "
+			"delimited by end-of-file (wanted '%s')\n", delim);
+		//return (pipefd[0]);
+	}
 	return (pipefd[0]);
+}
+
+//TRY NEW APPROACH OF NOT CREATING A PROCESS TO EXECUTE HEREDOC
+
+void	heredoc_sig_handler(int ignore)
+{
+	(void)ignore;
+	g_heredoc_sig = 1;
+	//printf("GOT HEREDOC SIG HANDLER\n");
+	rl_on_new_line();
+	rl_replace_line("", 0);
+	//printf("> ^C\n");
+	//write(STDOUT_FILENO, "\n", 1);
+	//rl_on_new_line();
+	rl_redisplay();
+	rl_done = 1;
+}
+
+int	handle_all_heredocs(t_parse_data *pd)
+{
+	struct sigaction	orig_int;
+	struct sigaction	sa;
+	t_command			*cmd;
+	int					i;
+
+	i = 0;
+	sa.sa_handler = heredoc_sig_handler;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+	sigaction(SIGINT, &sa, &orig_int);
+	while (i < pd->n_cmds)
+	{
+		cmd = pd->commands[i];
+		if (!cmd->hd_delim)//skips commands with no heredocs
+		{
+			i++;
+			continue ;
+		}
+
+		int pipefd[2];
+		if (pipe(pipefd) < 0)
+			return (-1);
+		int	rd = pipefd[0];
+		//int	wr = pipefd[1];
+		cmd->heredoc_fd = rd;
+		//close(pipefd[0]);
+
+		g_heredoc_sig = 0;
+		while (!g_heredoc_sig)
+		{
+			char *line = readline("> ");
+			if (!line)  // Ctrl-D
+			{
+				ft_printf("minishell: warning: here-document delimited by end-of-file (wanted '%s')\n", cmd->hd_delim);
+				//write(STDOUT_FILENO, "\n", 1);
+				//g_heredoc_sig = 1;
+				break;
+			}
+			if (ft_strcmp(line, cmd->hd_delim) == 0)
+			{
+				free(line);
+				break;
+			}
+			write(pipefd[1], line, ft_strlen(line));
+			write(pipefd[1], "\n", 1);
+			free(line);
+		}
+		close(pipefd[1]);
+		if (g_heredoc_sig)
+		{
+			// Ctrl-C: clean up and abort
+			close(cmd->heredoc_fd);
+			sigaction(SIGINT, &orig_int, NULL);
+			return (-1);
+		}
+		g_heredoc_sig = 0;  // reset for next heredoc
+		i++;
+	}
+	sigaction(SIGINT, &orig_int, NULL);
+	return 0;
 }

--- a/lexer.h
+++ b/lexer.h
@@ -44,7 +44,7 @@ typedef struct s_lexer
 	int		token_count;
 	char	*path;
 	char	*args[MAX_ARGS];
-	int	exit_status; // status do ultimo comando executado
+	int		exit_status; // status do ultimo comando executado
 	pid_t	last_bg_pid;  // PID do ultimo processo em background (para casos de fork ou sleep por ex)
 }			t_lexer;
 

--- a/main.c
+++ b/main.c
@@ -6,11 +6,14 @@
 /*   By: dopereir <dopereir@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/28 23:15:37 by dopereir          #+#    #+#             */
-/*   Updated: 2025/07/06 22:34:55 by dopereir         ###   ########.fr       */
+/*   Updated: 2025/07/19 02:08:59 by dopereir         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "libft/libft.h"
 #include "minishell.h"
+#include <readline/history.h>
+#include <signal.h>
 
 //handle ctrl-D later
 // ctrl-c (sigint)
@@ -99,7 +102,7 @@ void print_command_tree(t_command *cmd, int depth)
 }
 
 // Função para testar comandos específicos
-void test_specific_commands(void)
+void test_specific_commands(t_env *my_env)
 {
 	printf("\n=== TESTANDO COMANDOS ESPECÍFICOS ===\n");
 
@@ -136,7 +139,7 @@ void test_specific_commands(void)
 		print_tokens(lexer);
 
 		// Parsing
-		t_command *cmd = parse_function(lexer);
+		t_command *cmd = parse_function(lexer, my_env);
 		if (cmd)
 		{
 			printf("Parse Tree:\n");
@@ -160,7 +163,7 @@ void test_specific_commands(void)
 }
 
 // Função para validar se o parsing está correto
-int validate_parsing(void)
+int validate_parsing(t_env *my_env)
 {
 	printf("\n=== VALIDAÇÃO DE PARSING ===\n");
 	int errors = 0;
@@ -173,7 +176,7 @@ int validate_parsing(void)
 		lexer->token_count = 0;
 
 		lexing_input(lexer, ' ');
-		t_command *cmd = parse_function(lexer);
+		t_command *cmd = parse_function(lexer, my_env);
 
 		if (!cmd || cmd->type != T_WORD || !cmd->name || strcmp(cmd->name, "ls") != 0)
 		{
@@ -201,7 +204,7 @@ int validate_parsing(void)
 		lexer->token_count = 0;
 
 		lexing_input(lexer, ' ');
-		t_command *cmd = parse_function(lexer);
+		t_command *cmd = parse_function(lexer, my_env);
 
 		if (!cmd || cmd->type != T_PIPE || cmd->command_count != 2)
 		{
@@ -229,7 +232,7 @@ int validate_parsing(void)
 		lexer->token_count = 0;
 
 		lexing_input(lexer, ' ');
-		t_command *cmd = parse_function(lexer);
+		t_command *cmd = parse_function(lexer, my_env);
 
 		if (!cmd || cmd->type != T_AND || cmd->command_count != 2)
 		{
@@ -260,18 +263,28 @@ int main(int argc, char **argv, char **envp)
 	t_parse_data	pd;
 	t_env			*my_env;
 	char			*input;
+	struct sigaction	sa_int = {0}, sa_quit = {0};
+
+	sa_int.sa_handler = sigint_handler;
+	sigemptyset(&sa_int.sa_mask);
+	sa_int.sa_flags = SA_RESTART;
+	sigaction(SIGINT, &sa_int, NULL);
+
+	sa_quit.sa_handler = SIG_IGN;//instead of sigquit_handler;
+	sigemptyset(&sa_quit.sa_mask);
+	sa_quit.sa_flags = 0;
+	sigaction(SIGQUIT, &sa_quit, NULL);
 
 	(void)argc;
 	(void)argv;
-   // int mode = 0; // 0 = interativo, 1 = teste automático
 
-	printf("=== MINISHELL PARSER TESTER ===\n");
+	/*printf("=== MINISHELL PARSER TESTER ===\n");
 	printf("Comandos especiais:\n");
 	printf("  'test'     - Executa testes automáticos\n");
 	printf("  'validate' - Executa validação de parsing\n");
 	printf("  'exit'     - Sair do programa\n");
 	printf("  'clear'    - Limpar tela\n");
-	printf("================================\n\n");
+	printf("================================\n\n");*/
 
 	lexer = malloc(sizeof(t_lexer));
 	lexer->input = NULL;
@@ -284,11 +297,8 @@ int main(int argc, char **argv, char **envp)
 	{
 		input = readline("MINISHELL>$ ");
 
-		if (!input)
-		{
-			printf("\nSaindo...\n");
+		if (!input) //CTRL-D EOF
 			break;
-		}
 
 		if (ft_strlen(input) == 0)
 		{
@@ -305,32 +315,36 @@ int main(int argc, char **argv, char **envp)
 		else if (ft_strcmp(input, "test") == 0)
 		{
 			free(input);
-			test_specific_commands();
+			test_specific_commands(my_env);
 			continue;
 		}
 		else if (ft_strcmp(input, "validate") == 0)
 		{
 			free(input);
-			validate_parsing();
+			validate_parsing(my_env);
 			continue;
 		}
-		// Processar comando normal
 
 		lexer->input = input;
 		lexer->tokens = NULL;
 		lexer->token_count = 0;
 
-		printf("\n--- LEXING ---\n");
+		//printf("\n--- LEXING ---\n");
 		lexing_input(lexer, ' ');
-		print_tokens(lexer);
+		//print_tokens(lexer);
 
-		printf("\n--- PARSING ---\n");
-		pd = format_parsed_data(lexer);
-		print_parsed_data(&pd);
-
+		//printf("\n--- PARSING ---\n");
+		pd = format_parsed_data(lexer, my_env); //MUST ALSO RECEIVE MY_ENV
+		//print_parsed_data(&pd);
+		if (handle_all_heredocs(&pd) < 0)
+		{
+			add_history(input);
+			free_parsed_data(&pd);
+			free(input);
+			continue ;
+		}
 
 		exec_parsed_cmds(&pd, &my_env);
-		// BEFORE ALL THIS CREATE THE T_ENV VARIABLE AND INSTANCE
 		add_history(input);
 
 		// Libera tokens
@@ -341,15 +355,12 @@ int main(int argc, char **argv, char **envp)
 		}
 		if (lexer->tokens)
 			free(lexer->tokens);
-
+		free_parsed_data(&pd);
 		free(input);
-		printf("\n=======================END OF CMD===========================\n");
+		//printf("\n=======================END OF CMD===========================\n");
 	}
 
 	free(lexer);
 	clean_env_list(&my_env);
-	//add function to clean enlist
-	//add cleanup functions if needed
-	printf("Programa finalizado.\n");
 	return (0);
 }

--- a/minishell.h
+++ b/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nayara <nayara@student.42.fr>              +#+  +:+       +#+        */
+/*   By: dopereir <dopereir@student.42porto.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/20 01:10:10 by dopereir          #+#    #+#             */
-/*   Updated: 2025/07/06 22:07:33 by dopereir         ###   ########.fr       */
+/*   Updated: 2025/07/19 01:48:11 by dopereir         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,10 @@
 # include <stdbool.h>
 # include <sys/types.h>
 # include <sys/wait.h>
+# include <sys/ioctl.h>
+# include <termios.h>
 # include <fcntl.h>
+# include <errno.h> //to use errno extern
 # include "libft/libft.h"
 # include "lexer.h"
 # include "parser.h"
@@ -53,8 +56,8 @@ t_token			*split_tokens(char *str, char delim, t_lexer *lexer);
 void			lexing_input(t_lexer *lexer, char delim);
 //parser.c
 t_command		*init_command(void);
-t_command		*parse_function(t_lexer *lexer);
-t_command		*parse_sequence(t_lexer *lexer);
+//t_command		*parse_function(t_lexer *lexer);
+//t_command		*parse_sequence(t_lexer *lexer);
 t_command		*parse_pipeline(t_lexer *lexer);
 t_command		*parse_simple_command(t_lexer *lexer);
 int				has_pipes(t_lexer *lexer);
@@ -67,8 +70,8 @@ t_lexer			*create_sublexer(t_lexer *lexer, int start, int end);
 void			free_sublexer(t_lexer *sublexer);
 
 t_command	*init_command(void);
-t_command	*parse_function(t_lexer *lexer);
-t_command	*parse_sequence(t_lexer *lexer);
+t_command	*parse_function(t_lexer *lexer, t_env *my_env);
+t_command	*parse_sequence(t_lexer *lexer, t_env *my_env);
 t_command	*parse_pipeline(t_lexer *lexer);
 t_command	*parse_simple_command(t_lexer *lexer);
 int	has_pipes(t_lexer *lexer);
@@ -83,19 +86,20 @@ void	free_sublexer(t_lexer *sublexer);
 
 //collect_commands.c
 void			free_parsed_data(t_parse_data *parsed_data);
-t_parse_data	format_parsed_data(t_lexer *lexer);
+t_parse_data	format_parsed_data(t_lexer *lexer, t_env *my_env);
 void			print_parsed_data(const t_parse_data *pd);
 //execute_helpers.c
 char			*cmd_path_generator(char	*cmd_name);
 //exec_commands.c
 void			exec_parsed_cmds(t_parse_data *pd, t_env **env_list);
-//heredoc_handler.c
+//heredoc_utils.c
+void			heredoc_sig_handler(int ignore);
 int				set_heredoc(char *delim);
+int				handle_all_heredocs(t_parse_data *pd);
 //redirections_utils.c
 int				set_output(t_command *cmd);
 int				set_input(t_command *cmd);
 int				set_pipe(int *read_fd, int *write_fd);
-void			heredoc_sig_handler(int ignore);
 //environment_functions.c
 void			env_add(t_env **head, char *key, char *value);
 void			env_init(t_env **my_env, char **envp);
@@ -119,13 +123,12 @@ bool			is_any_builtin(char *name);
 //error_handlers.c
 char			*cmd_type_str(t_token_type type);
 void			argument_redirs_error(t_token_type type);
-
 int				set_heredoc(char *delim);
-
-
+//signal_handlers.c
+void			sigint_handler(int signo);
 //expand_var.c
-int	expand_variables(t_lexer *lexer);
-char	*get_special_var(char *var_name, t_lexer *lexer);
-void	update_last_bg_pid(t_lexer *lexer, pid_t pid);
+int				expand_variables(t_lexer *lexer, t_env *my_env);
+char			*get_special_var(char *var_name, t_lexer *lexer);
+void			update_last_bg_pid(t_lexer *lexer, pid_t pid);
 
 #endif

--- a/parser.c
+++ b/parser.c
@@ -50,7 +50,7 @@ t_command *init_command(void)
 
 t_command	*parse_simple_command(t_lexer *lexer)
 {
-	printf("**** ENTER PARSE_SIMPLE_CMD ******\n");
+	//printf("**** ENTER PARSE_SIMPLE_CMD ******\n");
 	t_command	*cmd;
 	int			args_count;
 	int			i;
@@ -184,7 +184,7 @@ t_command	*parse_simple_command(t_lexer *lexer)
 
 t_command	*parse_pipeline(t_lexer *lexer)
 {
-	printf("**** ENTER PARSE_PIPELINE ******\n");
+	//printf("**** ENTER PARSE_PIPELINE ******\n");
 	t_command	*pipeline_cmd;
 	t_lexer		*sublexer;
 	int		start;
@@ -241,9 +241,9 @@ t_command	*parse_pipeline(t_lexer *lexer)
 	return pipeline_cmd;
 }
 
-t_command	*parse_sequence(t_lexer *lexer)
+t_command	*parse_sequence(t_lexer *lexer, t_env *my_env)
 {
-	printf("**** ENTER PARSE_SEQUENCE ******\n");
+	//printf("**** ENTER PARSE_SEQUENCE ******\n");
 	t_command	*sequence_cmd;
 	t_lexer		*sublexer;
 	int		start;
@@ -278,7 +278,7 @@ t_command	*parse_sequence(t_lexer *lexer)
 			free_command(sequence_cmd);
 			return NULL;
 		}
-		sequence_cmd->commands[sequence_cmd->command_count] = parse_function(sublexer);
+		sequence_cmd->commands[sequence_cmd->command_count] = parse_function(sublexer, my_env);
 		if (!sequence_cmd->commands[sequence_cmd->command_count])
 		{
 			free_sublexer(sublexer);
@@ -294,18 +294,18 @@ t_command	*parse_sequence(t_lexer *lexer)
 	return sequence_cmd;
 }
 
-t_command	*parse_function(t_lexer *lexer)
+t_command	*parse_function(t_lexer *lexer, t_env *my_env)
 {
 	if (has_variables(lexer))
 	{
-		if (expand_variables(lexer) == -1)
+		if (expand_variables(lexer, my_env) == -1)
 		{
 			printf("minishell: error expanding variables\n");
 			return NULL;
 		}
 	}
 	if (has_logical_operators(lexer))
-		return parse_sequence(lexer);
+		return parse_sequence(lexer, my_env);
 	if (has_pipes(lexer))
 		return parse_pipeline(lexer);
 	else

--- a/parser.h
+++ b/parser.h
@@ -31,7 +31,8 @@ typedef struct s_command //mkdir test argv[0]
 	char				*output_file; // Output file for redirection
 	char				*argv[MAX_ARGS]; // Arguments for the command
 	char				*filename; //path to file redirection
-	char				*hd_delim;
+	char				*hd_delim; //delimiter to use on heredoc
+	int					heredoc_fd;
 	pid_t				pid_filename_output;
 	// para pipelines e sequencias
 	struct				s_command	**commands; // arrray de comandos filhos

--- a/parser_utils.c
+++ b/parser_utils.c
@@ -53,7 +53,7 @@ int	has_logical_operators(t_lexer *lexer)
 	return (0);
 }
 
-// conta quantos argumentos sao palavras (T_WORD) e nao redirecionamentos 
+// conta quantos argumentos sao palavras (T_WORD) e nao redirecionamentos
 int	count_args(t_lexer *lexer)
 {
 	int	i;
@@ -79,79 +79,83 @@ int	count_args(t_lexer *lexer)
 	}
 	return (count);
 }
-void free_command(t_command *cmd)
+
+void	free_command(t_command *cmd)
 {
-    int i;
-    
-    if (!cmd)
-        return;
-    
-    // Free basic string fields
-    if (cmd->name)
-    {
-        free(cmd->name);
-        cmd->name = NULL;
-    }
-    if (cmd->path)
-    {
-        free(cmd->path);
-        cmd->path = NULL;
-    }
-    if (cmd->input_file)
-    {
-        free(cmd->input_file);
-        cmd->input_file = NULL;
-    }
-    if (cmd->output_file)
-    {
-        free(cmd->output_file);
-        cmd->output_file = NULL;
-    }
-    if (cmd->filename)
-    {
-        free(cmd->filename);
-        cmd->filename = NULL;
-    }
-    
-    // Free argv array
-    i = 0;
-    while (i < MAX_ARGS && cmd->argv[i])
-    {
-        free(cmd->argv[i]);
-        cmd->argv[i] = NULL;
-        i++;
-    }
-    
-    // Free commands array
-    if (cmd->commands)
-    {
-        i = 0;
-        while (i < cmd->command_count && i < MAX_ARGS)
-        {
-            if (cmd->commands[i])
-            {
-                free_command(cmd->commands[i]);
-                cmd->commands[i] = NULL;
-            }
-            i++;
-        }
-        free(cmd->commands);
-        cmd->commands = NULL;
-    }
-    
-    // Free left and right commands (for tree structure)
-    if (cmd->left)
-    {
-        free_command(cmd->left);
-        cmd->left = NULL;
-    }
-    if (cmd->right)
-    {
-        free_command(cmd->right);
-        cmd->right = NULL;
-    }
-    
-    free(cmd);
+	int	i;
+
+	if (!cmd)
+		return;
+	if (cmd->name)
+	{
+		free(cmd->name);
+		cmd->name = NULL;
+	}
+	if (cmd->path)
+	{
+		free(cmd->path);
+		cmd->path = NULL;
+	}
+	if (cmd->input_file)
+	{
+		free(cmd->input_file);
+		cmd->input_file = NULL;
+	}
+	if (cmd->output_file)
+	{
+		free(cmd->output_file);
+		cmd->output_file = NULL;
+	}
+	if (cmd->filename)
+	{
+		free(cmd->filename);
+		cmd->filename = NULL;
+	}
+	if (cmd->hd_delim)
+	{
+		free(cmd->hd_delim);
+		cmd->hd_delim = NULL;
+	}
+
+	// Free argv array
+	i = 0;
+	while (i < MAX_ARGS && cmd->argv[i])
+	{
+		free(cmd->argv[i]);
+		cmd->argv[i] = NULL;
+		i++;
+	}
+
+	// Free commands array
+	if (cmd->commands)
+	{
+		i = 0;
+		while (i < cmd->command_count && i < MAX_ARGS)
+		{
+			if (cmd->commands[i])
+			{
+				free_command(cmd->commands[i]);
+				cmd->commands[i] = NULL;
+			}
+			i++;
+		}
+		free(cmd->commands);
+		cmd->commands = NULL;
+	}
+
+	// Free left and right commands (for tree structure)
+	if (cmd->left)
+	{
+		free_command(cmd->left);
+		cmd->left = NULL;
+	}
+	if (cmd->right)
+	{
+		free_command(cmd->right);
+		cmd->right = NULL;
+	}
+
+	free(cmd);
 }
 
 int	find_next_pipe(t_lexer *lexer, int start)

--- a/readline.supp
+++ b/readline.supp
@@ -1,0 +1,7 @@
+{
+	readline
+	Memcheck:Leak
+	fun:malloc
+	fun:xmalloc
+	fun:rl_initialize
+}

--- a/redirections_utils.c
+++ b/redirections_utils.c
@@ -88,13 +88,6 @@ int	set_pipe(int *read_fd, int *write_fd)
 	return (0);
 }
 
-void	heredoc_sig_handler(int ignore)
-{
-	ignore = 1;
-	g_heredoc_sig = 1;
-	write(ignore, "\n", 1);
-}
-
 //SET A SIGINT HANDLER SO IF ^C during the heredoc cancels the here-doc
 /*int	set_heredoc(char *delim)
 {

--- a/signal_handlers.c
+++ b/signal_handlers.c
@@ -1,0 +1,38 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   signal_handlers.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dopereir <dopereir@student.42porto.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/07/22 10:43:53 by dopereir          #+#    #+#             */
+/*   Updated: 2025/07/22 10:43:57 by dopereir         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+#include <readline/readline.h>
+
+//CTRL-C HANDLER
+void	sigint_handler(int signo)
+{
+	(void)signo;
+	if (g_heredoc_sig != 1)
+	{
+		printf("MINISHELL>$ %s^C\n", rl_line_buffer);
+		rl_replace_line("", 0);
+		rl_on_new_line();
+		rl_redisplay();
+	}
+	else if (g_heredoc_sig == 1)
+	{
+		printf("GOT MAIN SIG HANDLER\n");
+		rl_replace_line("", 0);
+		printf("> ^C\n");
+		rl_on_new_line();
+		rl_redisplay();
+		g_heredoc_sig = 0;
+	}
+}
+
+//CTRL-\ HANDLER (must ignore)


### PR DESCRIPTION
The readline.supp is a series of targets that valgrind will suppress in order to ignore some of the expected readline leaks.

1) Add and adapt your expand_var.c function to be fully compatible with the rest of the project.
2) Main changes is how the program catches and interpret signals, basically the program has to deal with signals in two scenarios, in the interactive mode, and in the heredoc mode, the default approach to every command is to be run as child process, but with heredocs this approach is prone to errors due to the image of the current terminal being used to the parent process, child process and in case of creating a heredoc in the child process, the grand-child process, all these 3 enviroments sharing metadate, stacks and signal handlers, to avoid this we now run the heredoc in the parent process, before executing the command itself, imagine the input: "cat  << EOF", previously we run this in a process created at the child process, now is called directly on the parent process to avoid interference, the g_heredoc_sig is used to signalize the handlers in which scenario we are, the normal interactive mode, or in a heredoc enviroment. This changes also allow the program to return better errors codes


THE NEXT STEPS:

Since all the elements are operational we now should test edge cases and do the necessaries modifications, the next improvements will be:

1) handle env variables expansion in the heredoc (like bash does)
2) send and catch correct error code
3) correct use single and double quotes at parsing/lexing phase
4) start to refactor the code to comply with norminette

and also lets test with valgrind after each successful alteration we make. 



